### PR TITLE
statement for File class

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -1,6 +1,7 @@
 <?php namespace Indikator\Filemanager\Controllers;
 
 use File;
+use BackendMenu;
 use Backend\Classes\Controller;
 use Backend\Models\UserPreferences;
 use System\Classes\PluginManager;
@@ -35,6 +36,8 @@ class Index extends Controller
                 $this->addJs('/plugins/anandpatel/wysiwygeditors/resources/assets/js/i18n/elfinder.'.$preferences['locale'].'.js');
             }
         }
+
+        BackendMenu::setContext('Indikator.Filemanager', 'pages');
     }
 
     public function fm_stat($folder = 'storage/app/uploads/public')

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -1,5 +1,6 @@
 <?php namespace Indikator\Filemanager\Controllers;
 
+use File;
 use Backend\Classes\Controller;
 use Backend\Models\UserPreferences;
 use System\Classes\PluginManager;


### PR DESCRIPTION
Without this declaration we will get an error like

![](https://sc-cdn.scaleengine.net/i/2b965946cc1e9fe28e9cc65fa4640fb9.png)

It is difficult to catch this bug, because it will appear only on fresh installation, where public folder is not exists.
